### PR TITLE
Prefer Throwable#toString to getMessage

### DIFF
--- a/retz-client/src/main/java/io/github/retz/cli/CommandGetJob.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandGetJob.java
@@ -82,13 +82,13 @@ public class CommandGetJob implements SubCommand {
             }
 
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
 

--- a/retz-client/src/main/java/io/github/retz/cli/CommandList.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandList.java
@@ -81,13 +81,13 @@ public class CommandList implements SubCommand {
             }
             return 0;
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/CommandListApp.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandListApp.java
@@ -61,13 +61,13 @@ public class CommandListApp implements SubCommand {
             }
             return 0;
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/CommandLoadApp.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandLoadApp.java
@@ -87,13 +87,13 @@ public class CommandLoadApp implements SubCommand {
             LOG.info(r.status());
             return 0;
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/CommandRun.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandRun.java
@@ -90,13 +90,13 @@ public class CommandRun implements SubCommand {
             }
 
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/CommandSchedule.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandSchedule.java
@@ -90,13 +90,13 @@ public class CommandSchedule implements SubCommand {
                 return -1;
             }
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/CommandUnloadApp.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandUnloadApp.java
@@ -60,13 +60,13 @@ public class CommandUnloadApp implements SubCommand {
             return 0;
 
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/CommandWatch.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandWatch.java
@@ -79,13 +79,13 @@ public class CommandWatch implements SubCommand{
             return 0;
 
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (ConnectException e) {
             LOG.error("Cannot connect to server {}", fileConfig.getUri());
         } catch (ExecutionException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            e.printStackTrace();
+            LOG.error(e.toString(), e);
         }
         return -1;
     }

--- a/retz-client/src/main/java/io/github/retz/cli/Launcher.java
+++ b/retz-client/src/main/java/io/github/retz/cli/Launcher.java
@@ -68,14 +68,14 @@ public class Launcher {
             }
 
         } catch (IOException e) {
-            LOG.error("Invalid configuration file: {}", e.getMessage());
+            LOG.error("Invalid configuration file: {}", e.toString());
         } catch (URISyntaxException e) {
-            LOG.error("Bad file format: {}", e.getMessage());
+            LOG.error("Bad file format: {}", e.toString());
         } catch (MissingCommandException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
             help(SUB_COMMANDS);
         } catch (ParameterException e) {
-            LOG.error("{}", e.getMessage());
+            LOG.error("{}", e.toString());
             help(SUB_COMMANDS);
         }
         //$ retz kill <jobid>

--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -60,7 +60,7 @@ public class Client implements AutoCloseable {
         try {
             wsclient.start();
         } catch (Exception e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         }
     }
 
@@ -244,7 +244,7 @@ public class Client implements AutoCloseable {
             conn = (HttpURLConnection) new URL(addr).openConnection();
             conn.setRequestMethod("GET");
         } catch (IOException e) {
-            LOG.error("Failed to fetch {}: {}", addr, e.getMessage());
+            LOG.error("Failed to fetch {}: {}", addr, e.toString());
             return;
         }
         conn.setDoOutput(true);
@@ -256,7 +256,7 @@ public class Client implements AutoCloseable {
                 out.write(buffer, 0, bytesRead);
             }
         } catch (IOException e) {
-            LOG.error("Cannot fetch file {}: {}", url, e.getMessage());
+            LOG.error("Cannot fetch file {}: {}", url, e.toString());
         }
         conn.disconnect();
     }
@@ -269,9 +269,9 @@ public class Client implements AutoCloseable {
         try {
             FileUtils.copyURLToFile(new URL(addr), new File(localfile));
         } catch (MalformedURLException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         } catch (IOException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         }
     }
 }

--- a/retz-client/src/main/java/io/github/retz/web/MySocket.java
+++ b/retz-client/src/main/java/io/github/retz/web/MySocket.java
@@ -124,10 +124,10 @@ public class MySocket {
         synchronized (this) {
             if (session != null) {
                 String msg = String.format("Connection error from %s: %s",
-                        session.getRemoteAddress().getHostName(), error.getMessage());
+                        session.getRemoteAddress().getHostName(), error.toString());
                 response = String.format("{\"status\":\"%s\", \"command\":\"error\"}", msg);
             } else {
-                response = String.format("{\"status\":\"%s\", \"command\":\"error\"}", error.getMessage());
+                response = String.format("{\"status\":\"%s\", \"command\":\"error\"}", error.toString());
             }
         }
         requestLatch.countDown();

--- a/retz-executor/src/main/java/io/github/retz/executor/FileManager.java
+++ b/retz-executor/src/main/java/io/github/retz/executor/FileManager.java
@@ -56,8 +56,7 @@ public class FileManager {
                             LOG.info("File {} was correctly decompressed before. Skipping decompression.", file);
                         }
                     } catch (ArchiveException e) {
-                        LOG.error("ArchiveException on {}: {}", f, e.getMessage());
-                        e.printStackTrace();
+                        LOG.error("ArchiveException on {}: {}", f, e.toString(), e);
                     }
                 }
             } else if (file.startsWith("http")) {
@@ -96,7 +95,7 @@ public class FileManager {
                 output.write(buffer, 0, bytesRead);
             }
         } catch (IOException e) {
-            LOG.debug(e.getMessage());
+            LOG.debug(e.toString());
             throw e;
         } finally {
             if (input != null) input.close();
@@ -124,7 +123,7 @@ public class FileManager {
                 }
                 return;
             } catch (InterruptedException e) {
-                LOG.error("Download process interrupted: {}", e.getMessage()); // TODO: debug?
+                LOG.error("Download process interrupted: {}", e.toString()); // TODO: debug?
             }
         }
     }
@@ -170,7 +169,7 @@ public class FileManager {
                 LOG.error("Failed decompression of file {}: {}", file, r);
             }
         } catch (InterruptedException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
         }
     }
 

--- a/retz-executor/src/main/java/io/github/retz/executor/LocalProcess.java
+++ b/retz-executor/src/main/java/io/github/retz/executor/LocalProcess.java
@@ -65,10 +65,7 @@ public class LocalProcess {
         try {
             FileManager.fetchPersistentFiles(metaJob.getApp().getPersistentFiles(), path, metaJob.getJob().trustPVFiles());
         } catch (IOException e) {
-            LOG.error("Cannot fetch persistent files: {}", e.getMessage());
-            if (LOG.isDebugEnabled()) {
-                e.printStackTrace();
-            }
+            LOG.error("Cannot fetch persistent files: {}", e.toString());
             return false;
         }
 
@@ -99,7 +96,7 @@ public class LocalProcess {
             LOG.info("Assigning CPU cores [{}] to {}", CPUManager.listIntToString(assigned), task.getTaskId());
             p = processBuilder.start();
         } catch (IOException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
             return false;
         }
         if (Objects.isNull(p)) {

--- a/retz-executor/src/main/java/io/github/retz/executor/LocalProcessManager.java
+++ b/retz-executor/src/main/java/io/github/retz/executor/LocalProcessManager.java
@@ -87,7 +87,7 @@ public class LocalProcessManager implements Runnable {
                 MANAGER.killed(task);
             }
         } catch (IOException e) {
-            LOG.debug(e.getMessage());
+            LOG.debug(e.toString());
             MANAGER.killed(task);
         }
 
@@ -165,7 +165,7 @@ public class LocalProcessManager implements Runnable {
                 MANAGER.poll();
                 Thread.sleep(512);
             } catch (InterruptedException e) {
-                LOG.warn("Polling error: {}", e.getMessage());
+                LOG.warn("Polling error: {}", e.toString());
             }
         }
     }

--- a/retz-server/src/main/java/io/github/retz/scheduler/JobQueue.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/JobQueue.java
@@ -128,7 +128,7 @@ public class JobQueue {
             try {
                 push(entry.getValue());
             } catch (InterruptedException e) {
-                LOG.warn("Interruption: Job(id={}) must be rerun ({})", entry.getValue().id(), e.getMessage());
+                LOG.warn("Interruption: Job(id={}) must be rerun ({})", entry.getValue().id(), e.toString());
                 continue; // Avoid remove in case we could retry removal again
             }
             it.remove();

--- a/retz-server/src/main/java/io/github/retz/scheduler/MesosFrameworkLauncher.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/MesosFrameworkLauncher.java
@@ -40,13 +40,13 @@ public final class MesosFrameworkLauncher {
         try {
             conf = parseConfiguration(argv);
         } catch (ParseException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
             return -1;
         } catch (URISyntaxException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
             return -1;
         } catch (IOException e) {
-            LOG.error(e.getMessage());
+            LOG.error(e.toString());
             return -1;
         }
 
@@ -57,7 +57,7 @@ public final class MesosFrameworkLauncher {
         try {
             driver = new MesosSchedulerDriver(scheduler, fw, conf.getMesosMaster());
         } catch (Exception e) {
-            LOG.error("Cannot start Mesos scheduler: {}", e.getMessage());
+            LOG.error("Cannot start Mesos scheduler: {}", e.toString());
             return -1;
         }
         Protos.Status status = driver.start();

--- a/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
@@ -362,7 +362,7 @@ public class RetzScheduler implements Scheduler {
                     status.getTaskId().getValue(), job.id(), status.getState().name());
             WebConsole.notifyFinished(job);
         } catch (Exception e) {
-            String msg = String.format("Failed to parse message from executor: %s '%s'", e.getMessage(), status.getMessage());
+            String msg = String.format("Failed to parse message from executor: %s '%s'", e.toString(), status.getMessage());
             LOG.warn(msg);
             job.killed(TimestampHelper.now(), msg);
             WebConsole.notifyKilled(job);
@@ -385,7 +385,7 @@ public class RetzScheduler implements Scheduler {
         } catch (NumberFormatException e) {
             String msg = String.format("Failed to parse message from executor: '%s'", status.getMessage());
             LOG.warn(msg);
-            LOG.warn("Exception: {}", e.getMessage());
+            LOG.warn("Exception: {}", e.toString());
             job.killed(TimestampHelper.now(), msg);
             WebConsole.notifyKilled(job);
         }

--- a/retz-server/src/main/java/io/github/retz/web/ConsoleWebSocketHandler.java
+++ b/retz-server/src/main/java/io/github/retz/web/ConsoleWebSocketHandler.java
@@ -73,7 +73,7 @@ public class ConsoleWebSocketHandler {
             try {
                 s.getRemote().sendString(msg);
             } catch (IOException e) {
-                LOG.warn("cannot send to {}: {}", s.getRemoteAddress().getHostName(), e.getMessage());
+                LOG.warn("cannot send to {}: {}", s.getRemoteAddress().getHostName(), e.toString());
             }
         }
     }
@@ -84,7 +84,7 @@ public class ConsoleWebSocketHandler {
                 ByteBuffer ping = ByteBuffer.wrap("ping".getBytes(StandardCharsets.UTF_8));
                 s.getRemote().sendPing(ping);
             } catch (IOException e) {
-                LOG.warn("cannot send to {}: {}", s.getRemoteAddress().getHostName(), e.getMessage());
+                LOG.warn("cannot send to {}: {}", s.getRemoteAddress().getHostName(), e.toString());
                 s.close();
                 WATCHERS.remove(s);
             }
@@ -94,7 +94,7 @@ public class ConsoleWebSocketHandler {
                 ByteBuffer ping = ByteBuffer.wrap("ping".getBytes(StandardCharsets.UTF_8));
                 watcher.getValue().getRemote().sendPing(ping);
             } catch (IOException e) {
-                LOG.warn("cannot send to {}: {}", watcher.getValue().getRemoteAddress().getHostName(), e.getMessage());
+                LOG.warn("cannot send to {}: {}", watcher.getValue().getRemoteAddress().getHostName(), e.toString());
                 watcher.getValue().close();
                 JOB_WATCHERS.remove(watcher.getKey());
             }
@@ -117,11 +117,11 @@ public class ConsoleWebSocketHandler {
                     JOB_WATCHERS.remove(job.id());
                 }
             } catch (JsonProcessingException e) {
-                LOG.error("Cannot encode Job {}: {}", job, e.getMessage());
+                LOG.error("Cannot encode Job {}: {}", job, e.toString());
             } catch (IOException e) {
                 LOG.warn("Cannot send {} to {}", update, s.getRemoteAddress());
             } catch (WebSocketException e) {
-                LOG.error("Client were disconnected: {}", e.getMessage());
+                LOG.error("Client were disconnected: {}", e.toString());
             }
         }
     }
@@ -157,7 +157,7 @@ public class ConsoleWebSocketHandler {
         try {
             req = MAPPER.readValue(message, Request.class);
         } catch (IOException e) {
-            respond(user, new ErrorResponse("Invalid command: " + e.getMessage()));
+            respond(user, new ErrorResponse("Invalid command: " + e.toString()));
             return;
         } catch (NullPointerException e) {
             LOG.error("NullPointerException: {}", user);

--- a/retz-server/src/main/java/io/github/retz/web/WebConsole.java
+++ b/retz-server/src/main/java/io/github/retz/web/WebConsole.java
@@ -97,7 +97,7 @@ public final class WebConsole {
         try {
             clientMonitorThread.join();
         } catch (InterruptedException e) {
-            LOG.warn("Can't join client monitor thread: " + e.getMessage());
+            LOG.warn("Can't join client monitor thread: " + e.toString());
         }
         Spark.stop();
     }


### PR DESCRIPTION
In default implementation, getMessage is included in toString.
Moreover, in some exception classes, class names are descriptive and
messages may be empty.

This commit also avoid Thorowable#printStackTrace() because it
prevents users to control stream to output the information.
