### PR TITLE
Fix CPUManagerTest#cpuManagerTest affected by RetzExecutorTest leakin…

### DIFF
--- a/retz-executor/src/main/java/io/github/retz/executor/LocalProcess.java
+++ b/retz-executor/src/main/java/io/github/retz/executor/LocalProcess.java
@@ -63,6 +63,7 @@ public class LocalProcess {
         }
 
         try {
+            // TODO: this is actually done in LocalProcessManager singleton thread, which may block other task invocations
             FileManager.fetchPersistentFiles(metaJob.getApp().getPersistentFiles(), path, metaJob.getJob().trustPVFiles());
         } catch (IOException e) {
             LOG.error("Cannot fetch persistent files: {}", e.toString());

--- a/retz-executor/src/main/java/io/github/retz/executor/RetzExecutor.java
+++ b/retz-executor/src/main/java/io/github/retz/executor/RetzExecutor.java
@@ -113,6 +113,8 @@ public class RetzExecutor implements Executor {
     @Override
     public void shutdown(ExecutorDriver driver) {
         LOG.info("Executor shutting down");
+        LocalProcessManager.stop();
+        LocalProcessManager.join();
     }
 
     // Only for tests

--- a/retz-executor/src/test/java/io/github/retz/executor/CPUManagerTest.java
+++ b/retz-executor/src/test/java/io/github/retz/executor/CPUManagerTest.java
@@ -17,6 +17,7 @@
 package io.github.retz.executor;
 
 import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import scala.actors.threadpool.Arrays;
 import xerial.jnuma.Numa;
@@ -27,6 +28,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class CPUManagerTest {
+
+    @Before
+    public void before() {
+    }
 
     @After
     public void after() {
@@ -73,5 +78,14 @@ public class CPUManagerTest {
 
         CPUManager.get().free("hey><");
         assertEquals(4 * nodes.length, CPUManager.get().availableCPUCount());
+    }
+
+    @Test
+    public void notEnough () {
+        Integer[] nodes = {4, 4, 4, 4};
+        CPUManager.setTopology(Arrays.asList(nodes));
+
+        List<Integer> cpus = CPUManager.get().assign("not-enough", 32);
+        assertTrue(cpus.isEmpty());
     }
 }


### PR DESCRIPTION
…g CPU
- Add end-to-end checking of total avilable CPU cores at each
  RetzExecutorTest tests
- Fix immature error handling at LocalProcessManager.start
- Add shutdown handling on MesosExecutorDriver.stop() to stop
  LocalProcessMaanager thread
- Other code cleanup
