### PR TITLE
Add build configuration for Eclipse

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'nebula-aggregate-javadocs'
 subprojects {
     apply plugin: 'java'
     apply plugin: 'scala'
+    apply plugin: 'eclipse'
     apply plugin: 'findbugs'
     apply plugin: "com.github.hierynomus.license"
 
@@ -71,6 +72,10 @@ subprojects {
         ext.name = 'Nautilus Technologies, Inc.'
 
         excludes(["**/*.json", "**/*.jks"])
+    }
+
+    eclipse {
+        project.buildCommand 'org.eclipse.jdt.core.javabuilder'
     }
 }
 


### PR DESCRIPTION
This PR adds build configuration for Eclipse.

Gradle eclipse plugin eliminates javabuilder from eclipse .project file when applying scala plugin ( https://issues.gradle.org/browse/GRADLE-2588 ) but retz should take priority of java development environment so this PR adds javabuilder as default configration for generating  eclipse project.
