### PR TITLE
Use Feign for Retz client.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ project(':retz-client') {
 
         compile "com.beust:jcommander:1.58"
         compile 'commons-io:commons-io:2.5'
+        compile 'io.github.openfeign:feign-jackson:9.4.0'
     }
 
 

--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
 import java.util.ResourceBundle;
 
 import org.slf4j.Logger;
@@ -94,7 +95,8 @@ public class Client implements AutoCloseable {
             throw new IllegalArgumentException("Priority must be [-19, 20]");
         }
         return Retz.tryOrErrorResponse(
-                () -> Retz.connect(uri, authenticator).schedule(job));
+                () -> Retz.connect(uri, authenticator)
+                        .schedule(Objects.requireNonNull(job)));
     }
 
     public Response getJob(int id) throws IOException {
@@ -104,12 +106,14 @@ public class Client implements AutoCloseable {
 
     public Response getFile(int id, String file, long offset, long length) throws IOException {
         return Retz.tryOrErrorResponse(
-                () -> Retz.connect(uri, authenticator).getFile(id, file, offset, length));
+                () -> Retz.connect(uri, authenticator)
+                        .getFile(id, Objects.requireNonNull(file), offset, length));
     }
 
     public Response listFiles(int id, String path) throws IOException {
         return Retz.tryOrErrorResponse(
-                () -> Retz.connect(uri, authenticator).listFiles(id, path));
+                () -> Retz.connect(uri, authenticator)
+                        .listFiles(id, Objects.requireNonNull(path)));
     }
 
     public Job run(Job job) throws IOException {
@@ -163,7 +167,8 @@ public class Client implements AutoCloseable {
 
     public Response load(Application application) throws IOException {
         return Retz.tryOrErrorResponse(
-                () -> Retz.connect(uri, authenticator).load(application));
+                () -> Retz.connect(uri, authenticator)
+                        .load(Objects.requireNonNull(application)));
     }
 
     public Response listApp() throws IOException {
@@ -174,6 +179,7 @@ public class Client implements AutoCloseable {
     @Deprecated
     public Response unload(String appName) throws IOException {
         return Retz.tryOrErrorResponse(
-                () -> Retz.connect(uri, authenticator).unload(appName));
+                () -> Retz.connect(uri, authenticator)
+                        .unload(Objects.requireNonNull(appName)));
     }
 }

--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -32,7 +32,7 @@ import io.github.retz.protocol.Response;
 import io.github.retz.protocol.ScheduleResponse;
 import io.github.retz.protocol.data.Application;
 import io.github.retz.protocol.data.Job;
-import io.github.retz.web.feign.Server;
+import io.github.retz.web.feign.Retz;
 
 public class Client implements AutoCloseable {
 
@@ -77,7 +77,7 @@ public class Client implements AutoCloseable {
 
     public boolean ping() throws IOException {
         try {
-            return "OK".equals(Server.connect(uri, authenticator).ping());
+            return "OK".equals(Retz.connect(uri, authenticator).ping());
         } catch (FeignException e) {
             LOG.debug(e.toString());
             return false;
@@ -85,31 +85,31 @@ public class Client implements AutoCloseable {
     }
 
     public Response list(int limit) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).list());
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).list());
     }
 
     public Response schedule(Job job) throws IOException {
         if (job.priority() < -20 || 19 < job.priority()) {
             throw new IllegalArgumentException("Priority must be [-19, 20]");
         }
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).schedule(job));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).schedule(job));
     }
 
     public Response getJob(int id) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).getJob(id));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).getJob(id));
     }
 
     public Response getFile(int id, String file, long offset, long length) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).getFile(id, file, offset, length));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).getFile(id, file, offset, length));
     }
 
     public Response listFiles(int id, String path) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).listFiles(id, path));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).listFiles(id, path));
     }
 
     public Job run(Job job) throws IOException {
@@ -152,28 +152,28 @@ public class Client implements AutoCloseable {
     }
 
     public Response kill(int id) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).kill(id));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).kill(id));
     }
 
     public Response getApp(String appid) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).getApp(appid));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).getApp(appid));
     }
 
     public Response load(Application application) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).load(application));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).load(application));
     }
 
     public Response listApp() throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).listApp());
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).listApp());
     }
 
     @Deprecated
     public Response unload(String appName) throws IOException {
-        return Server.tryOrErrorResponse(
-                () -> Server.connect(uri, authenticator).unload(appName));
+        return Retz.tryOrErrorResponse(
+                () -> Retz.connect(uri, authenticator).unload(appName));
     }
 }

--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -45,10 +45,13 @@ public class Client implements AutoCloseable {
         VERSION_STRING = labels.getString("version");
     }
 
-    private final Server server;
+    private final URI uri;
+
+    private final Authenticator authenticator;
 
     protected Client(URI uri, Authenticator authenticator) {
-        this.server = Server.connect(uri, authenticator);
+        this.uri = uri;
+        this.authenticator = authenticator;
     }
 
     protected Client(URI uri, Authenticator authenticator, boolean checkCert) {
@@ -74,7 +77,7 @@ public class Client implements AutoCloseable {
 
     public boolean ping() throws IOException {
         try {
-            return "OK".equals(server.ping());
+            return "OK".equals(Server.connect(uri, authenticator).ping());
         } catch (FeignException e) {
             LOG.debug(e.toString());
             return false;
@@ -82,26 +85,31 @@ public class Client implements AutoCloseable {
     }
 
     public Response list(int limit) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.list());
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).list());
     }
 
     public Response schedule(Job job) throws IOException {
         if (job.priority() < -20 || 19 < job.priority()) {
             throw new IllegalArgumentException("Priority must be [-19, 20]");
         }
-        return Server.tryOrErrorResponse(() -> server.schedule(job));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).schedule(job));
     }
 
     public Response getJob(int id) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.getJob(id));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).getJob(id));
     }
 
     public Response getFile(int id, String file, long offset, long length) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.getFile(id, file, offset, length));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).getFile(id, file, offset, length));
     }
 
     public Response listFiles(int id, String path) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.listFiles(id, path));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).listFiles(id, path));
     }
 
     public Job run(Job job) throws IOException {
@@ -144,23 +152,28 @@ public class Client implements AutoCloseable {
     }
 
     public Response kill(int id) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.kill(id));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).kill(id));
     }
 
     public Response getApp(String appid) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.getApp(appid));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).getApp(appid));
     }
 
     public Response load(Application application) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.load(application));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).load(application));
     }
 
     public Response listApp() throws IOException {
-        return Server.tryOrErrorResponse(() -> server.listApp());
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).listApp());
     }
 
     @Deprecated
     public Response unload(String appName) throws IOException {
-        return Server.tryOrErrorResponse(() -> server.unload(appName));
+        return Server.tryOrErrorResponse(
+                () -> Server.connect(uri, authenticator).unload(appName));
     }
 }

--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -25,6 +25,7 @@ import java.util.ResourceBundle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import feign.FeignException;
 import io.github.retz.auth.Authenticator;
 import io.github.retz.protocol.GetJobResponse;
 import io.github.retz.protocol.Response;
@@ -72,7 +73,12 @@ public class Client implements AutoCloseable {
     }
 
     public boolean ping() throws IOException {
-        return "OK".equals(server.ping());
+        try {
+            return "OK".equals(server.ping());
+        } catch (FeignException e) {
+            LOG.debug(e.toString());
+            return false;
+        }
     }
 
     public Response list(int limit) throws IOException {

--- a/retz-client/src/main/java/io/github/retz/web/feign/AuthHeaderInterceptor.java
+++ b/retz-client/src/main/java/io/github/retz/web/feign/AuthHeaderInterceptor.java
@@ -1,0 +1,70 @@
+/**
+ *    Retz
+ *    Copyright (C) 2016 Nautilus Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.github.retz.web.feign;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import io.github.retz.auth.AuthHeader;
+import io.github.retz.auth.Authenticator;
+import io.github.retz.cli.TimestampHelper;
+
+public class AuthHeaderInterceptor implements RequestInterceptor {
+
+    private static final ThreadLocal<MessageDigest> DIGEST = ThreadLocal
+            .withInitial(() -> {
+                try {
+                    return MessageDigest.getInstance("MD5");
+                } catch (NoSuchAlgorithmException e) {
+                    throw new AssertionError("No such algorithm callled MD5.", e);
+                }
+            });
+
+    private final Authenticator authenticator;
+
+    public AuthHeaderInterceptor(Authenticator authenticator) {
+        this.authenticator = authenticator;
+    }
+
+    @Override
+    public void apply(RequestTemplate template) {
+        String md5 = "";
+        byte[] body = template.body();
+        if (body != null) {
+            md5 = Base64.getEncoder().withoutPadding().encodeToString(DIGEST.get().digest(body));
+            template.header("Content-MD5", md5);
+        }
+
+        String date = TimestampHelper.now();
+        template.header("Date", date);
+
+        String resource;
+        try {
+            resource = new URI(template.url()).getPath() + template.queryLine();
+        } catch (URISyntaxException e) {
+            throw new AssertionError(e);
+        }
+
+        String header = authenticator.header(template.method(), md5, date, resource).buildHeader();
+        template.header(AuthHeader.AUTHORIZATION, header);
+    }
+}

--- a/retz-client/src/main/java/io/github/retz/web/feign/ErrorResponseDecoder.java
+++ b/retz-client/src/main/java/io/github/retz/web/feign/ErrorResponseDecoder.java
@@ -62,10 +62,14 @@ public class ErrorResponseDecoder implements ErrorDecoder {
                                     fex.status(), fex.getMessage(),
                                     mapper.readValue(value, ErrorResponse.class));
                         } catch (IOException e) {
-                            return ex;
+                            return new ErrorResponseException(
+                                    fex.status(), fex.getMessage(),
+                                    new ErrorResponse(value));
                         }
                     })
-                    .orElseGet(() -> ex);
+                    .orElseGet(() -> new ErrorResponseException(
+                            fex.status(), fex.getMessage(),
+                            new ErrorResponse(fex.toString())));
         } else {
             return ex;
         }

--- a/retz-client/src/main/java/io/github/retz/web/feign/ErrorResponseDecoder.java
+++ b/retz-client/src/main/java/io/github/retz/web/feign/ErrorResponseDecoder.java
@@ -1,0 +1,84 @@
+/**
+ *    Retz
+ *    Copyright (C) 2016 Nautilus Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.github.retz.web.feign;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import feign.FeignException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import io.github.retz.protocol.ErrorResponse;
+
+public class ErrorResponseDecoder implements ErrorDecoder {
+
+    private final ObjectMapper mapper;
+
+    private final ErrorDecoder delegate;
+
+    private final Function<String, Optional<String>> extractor;
+
+    public ErrorResponseDecoder(ObjectMapper mapper) {
+        this(mapper, new ErrorDecoder.Default(), ErrorResponseDecoder::extract);
+    }
+
+    public ErrorResponseDecoder(
+            ObjectMapper mapper,
+            ErrorDecoder delegate,
+            Function<String, Optional<String>> extractor) {
+        this.mapper = mapper;
+        this.delegate = delegate;
+        this.extractor = extractor;
+    }
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        Exception ex = delegate.decode(methodKey, response);
+        if (ex instanceof ErrorResponseException) {
+            return ex;
+        } else if (ex instanceof FeignException) {
+            FeignException fex = (FeignException) ex;
+            return extractor.apply(fex.getMessage())
+                    .map(value -> {
+                        try {
+                            return new ErrorResponseException(
+                                    fex.status(), fex.getMessage(),
+                                    mapper.readValue(value, ErrorResponse.class));
+                        } catch (IOException e) {
+                            return ex;
+                        }
+                    })
+                    .orElseGet(() -> ex);
+        } else {
+            return ex;
+        }
+    }
+
+    private static final String SEPARATOR = "; content:\n";
+
+    private static Optional<String> extract(String message) {
+        int idx = message.indexOf(SEPARATOR);
+        if (idx >= 0) {
+            return Optional.of(message.substring(idx + SEPARATOR.length()));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/retz-client/src/main/java/io/github/retz/web/feign/ErrorResponseException.java
+++ b/retz-client/src/main/java/io/github/retz/web/feign/ErrorResponseException.java
@@ -1,0 +1,34 @@
+/**
+ *    Retz
+ *    Copyright (C) 2016 Nautilus Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.github.retz.web.feign;
+
+import feign.FeignException;
+import io.github.retz.protocol.ErrorResponse;
+
+public class ErrorResponseException extends FeignException {
+
+    private final ErrorResponse err;
+
+    public ErrorResponseException(int status, String message, ErrorResponse err) {
+        super(status, message);
+        this.err = err;
+    }
+
+    public ErrorResponse getErr() {
+        return err;
+    }
+}

--- a/retz-client/src/main/java/io/github/retz/web/feign/Retz.java
+++ b/retz-client/src/main/java/io/github/retz/web/feign/Retz.java
@@ -36,7 +36,7 @@ import io.github.retz.protocol.ScheduleRequest;
 import io.github.retz.protocol.data.Application;
 import io.github.retz.protocol.data.Job;
 
-public interface Server {
+public interface Retz {
 
     @RequestLine("GET /ping")
     String ping();
@@ -91,7 +91,7 @@ public interface Server {
     @RequestLine("DELETE /app/{appid}")
     Response unload(@Param("appid") String appid);
 
-    static Server connect(URI uri, Authenticator authenticator) {
+    static Retz connect(URI uri, Authenticator authenticator) {
         String url = Objects.requireNonNull(uri, "uri cannot be null").toString();
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());
@@ -100,7 +100,7 @@ public interface Server {
                 .decoder(new JacksonDecoder(mapper))
                 .errorDecoder(new ErrorResponseDecoder(mapper))
                 .requestInterceptor(new AuthHeaderInterceptor(authenticator))
-                .target(Server.class, url);
+                .target(Retz.class, url);
     }
 
     static Response tryOrErrorResponse(Supplier<Response> supplier) throws IOException {

--- a/retz-client/src/main/java/io/github/retz/web/feign/Server.java
+++ b/retz-client/src/main/java/io/github/retz/web/feign/Server.java
@@ -1,0 +1,115 @@
+/**
+ *    Retz
+ *    Copyright (C) 2016 Nautilus Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package io.github.retz.web.feign;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+import feign.Feign;
+import feign.Param;
+import feign.RequestLine;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.github.retz.auth.Authenticator;
+import io.github.retz.protocol.LoadAppRequest;
+import io.github.retz.protocol.Response;
+import io.github.retz.protocol.ScheduleRequest;
+import io.github.retz.protocol.data.Application;
+import io.github.retz.protocol.data.Job;
+
+public interface Server {
+
+    @RequestLine("GET /ping")
+    String ping();
+
+    @RequestLine("GET /jobs")
+    Response list();
+
+    default Response schedule(Job job) {
+        return schedule(new ScheduleRequest(job));
+    }
+
+    @RequestLine("POST /job")
+    Response schedule(ScheduleRequest request);
+
+    @RequestLine("GET /job/{id}")
+    Response getJob(@Param("id") int id);
+
+    @RequestLine("GET /job/{id}/file?path={path}&offset={offset}&length={length}")
+    Response getFile(
+            @Param("id") int id,
+            @Param("path") String path,
+            @Param("offset") long offset,
+            @Param("length") long length);
+
+    @RequestLine("GET /job/{id}/dir?path={path}")
+    Response listFiles(@Param("id") int id, @Param("path") String path);
+
+    default Response run(Job job) {
+        return run(new ScheduleRequest(job));
+    }
+
+    @RequestLine("POST /job")
+    Response run(ScheduleRequest request);
+
+    @RequestLine("DELETE /job/{id}")
+    Response kill(@Param("id") int id);
+
+    @RequestLine("GET /app/{appid}")
+    Response getApp(@Param("appid") String appid);
+
+    default Response load(Application application) {
+        return load(application.getAppid(), new LoadAppRequest(application));
+    }
+
+    @RequestLine("PUT /app/{appid}")
+    Response load(@Param("appid") String appid, LoadAppRequest request);
+
+    @RequestLine("GET /apps")
+    Response listApp();
+
+    @Deprecated
+    @RequestLine("DELETE /app/{appid}")
+    Response unload(@Param("appid") String appid);
+
+    static Server connect(URI uri, Authenticator authenticator) {
+        String url = Objects.requireNonNull(uri, "uri cannot be null").toString();
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new Jdk8Module());
+        return Feign.builder()
+                .encoder(new JacksonEncoder(mapper))
+                .decoder(new JacksonDecoder(mapper))
+                .errorDecoder(new ErrorResponseDecoder(mapper))
+                .requestInterceptor(new AuthHeaderInterceptor(authenticator))
+                .target(Server.class, url);
+    }
+
+    static Response tryOrErrorResponse(Supplier<Response> supplier) throws IOException {
+        try {
+            return supplier.get();
+        } catch (ErrorResponseException ex) {
+            return ex.getErr();
+        } catch (Exception e) {
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+}

--- a/retz-server/src/main/java/io/github/retz/web/WebConsole.java
+++ b/retz-server/src/main/java/io/github/retz/web/WebConsole.java
@@ -166,7 +166,7 @@ public final class WebConsole {
         });
 
         // APIs to be in vanilla HTTP
-        get("/ping", (req, res) -> "OK");
+        get("/ping", (req, res) -> "\"OK\"");
         get("/status", WebConsole::status);
 
         // TODO: XXX: validate application owner at ALL job-related APIs


### PR DESCRIPTION
This pr modifies retz-client to use Feign to handle HTTP access to retz-server.

Related issue: #45.