### PR TITLE
Refine retz-client.

### DIFF
--- a/retz-client/src/main/java/io/github/retz/web/NoOpHostnameVerifier.java
+++ b/retz-client/src/main/java/io/github/retz/web/NoOpHostnameVerifier.java
@@ -16,25 +16,13 @@
  */
 package io.github.retz.web;
 
-import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
 
-import javax.net.ssl.X509TrustManager;
-
-// DANGER ZONE: this disables TLS certification and allow self-signed certificate
-// do not use this over internet
-// Copyright notice: this function is based on StackOverflow:19540289
-public class WrongTrustManager implements X509TrustManager {
+public class NoOpHostnameVerifier implements HostnameVerifier {
 
     @Override
-    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-        return null;
-    }
-
-    @Override
-    public void checkClientTrusted(X509Certificate[] certs, String authType) {
-    }
-
-    @Override
-    public void checkServerTrusted(X509Certificate[] certs, String authType) {
+    public boolean verify(String hostname, SSLSession session) {
+        return true;
     }
 }

--- a/retz-server/src/test/java/io/github/retz/web/WebConsoleCommonTests.java
+++ b/retz-server/src/test/java/io/github/retz/web/WebConsoleCommonTests.java
@@ -261,18 +261,18 @@ public class WebConsoleCommonTests {
         Job job = new Job(app.getAppid(), "foocmd", null, 12000, 12000);
         JobQueue.push(job);
 
-        URL url = new URL(config.getUri().toASCIIString() + "/status");
-        System.err.println(url);
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setRequestMethod("GET");
-        conn.setDoOutput(true);
-        Response res = mapper.readValue(conn.getInputStream(), Response.class);
-        assertThat(res, instanceOf(StatusResponse.class));
-        StatusResponse statusResponse = (StatusResponse) res;
+        try (Client c = Client.newBuilder(config.getUri())
+                .setAuthenticator(config.getAuthenticator())
+                .checkCert(!config.insecure())
+                .build()) {
+            Response res = c.status();
+            assertThat(res, instanceOf(StatusResponse.class));
+            StatusResponse statusResponse = (StatusResponse) res;
 
-        System.err.println(statusResponse.queueLength());
-        assertThat(statusResponse.queueLength(), is(1));
-        assertThat(statusResponse.sessionLength(), is(0));
+            System.err.println(statusResponse.queueLength());
+            assertThat(statusResponse.queueLength(), is(1));
+            assertThat(statusResponse.sessionLength(), is(0));
+        }
     }
 
     // Checks isolation between users.


### PR DESCRIPTION
This pr refines retz-client.

- Use `SSLSocketFactory` and `HostnameVerifier` in each connection instead of global configurations.
- Reuse `Retz` instance.
  - Now that I believe `Retz` instance is thread-safe, we can reuse it.