### PR TITLE
add a helper function to stream a file to a stream

### DIFF
--- a/retz-client/src/main/java/io/github/retz/web/ClientHelper.java
+++ b/retz-client/src/main/java/io/github/retz/web/ClientHelper.java
@@ -211,6 +211,12 @@ public class ClientHelper {
         }
     }
 
+    public static void getWholeBinaryFile(Client c, int id, String path, OutputStream out) throws IOException {
+        LOG.info("Saving {} to stream", path);
+        Pair<Integer, byte[]> result = c.getBinaryFile(id, path);
+        out.write(result.right());
+    }
+
     static long readFileUntilEmpty(Client c, int id, String filename, long offset, OutputStream out) throws IOException {
         int length = 65536;
         long current = offset;


### PR DESCRIPTION
As mentioned in #124, I need a helper function to stream a binary file to an `OutputStream` so I added it. This does not resolve the issue, but still I'd be happy if you could add this for the time being.