### PR TITLE
Fix to show killall error logs even if all the processes succeed

### DIFF
--- a/retz-client/src/main/java/io/github/retz/cli/CommandKillall.java
+++ b/retz-client/src/main/java/io/github/retz/cli/CommandKillall.java
@@ -103,8 +103,10 @@ public class CommandKillall implements SubCommand {
                 List<String> k = killed.stream().map(job -> Integer.toString(job.id())).collect(Collectors.toList());
                 LOG.info("Jobs killed: {}", String.join(", ", k));
             }
-            List<String> f = failed.stream().map(job -> Integer.toString(job.id())).collect(Collectors.toList());
-            LOG.error("Failed to kill jobs: [{}]", String.join(",", f));
+            if (!failed.isEmpty()) {
+                List<String> f = failed.stream().map(job -> Integer.toString(job.id())).collect(Collectors.toList());
+                LOG.error("Failed to kill jobs: [{}]", String.join(",", f));
+            }
 
         } while (r.more());
         return total;


### PR DESCRIPTION
This PR fixes to show error logs even if all the processes succeed when running `retz-client killall`.

```
INFO QUEUED: 6 jobs killed, 0 jobs failed
ERROR Failed to kill jobs: []
INFO STARTED: 4 jobs killed, 0 jobs failed
ERROR Failed to kill jobs: []
INFO STARTING: 0 jobs killed, 0 jobs failed
ERROR Failed to kill jobs: []
```