### PR TITLE
Respond to kill as json

### DIFF
--- a/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
+++ b/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
@@ -239,6 +239,7 @@ public class JobRequestHandler {
 
     static String kill(Request req, spark.Response res) throws JsonProcessingException {
         LOG.debug("kill", req.params(":id"));
+        res.type("application/json");
         int id = Integer.parseInt(req.params(":id"));
 
         Optional<Job> maybeJob;


### PR DESCRIPTION
It looks like the endpoint to kill a job respond as `text/html` instead of `application/json` although the response is actually json. I can't make consistent rules in my proxy server to Retz server because of this. Could you consider to merge this change?