### PR TITLE
Stream file

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -375,6 +375,7 @@ Server configuration file
 * ``retz.max.ports = 10``
 * ``retz.max.disk = 1024``
 * ``retz.max.list-jobs = 65536`` Max number of jobs that is allowed to retrieve from client
+* ``retz.max.file-size = 65536 * 1024`` Max file size of a download file, negative value indicates no limit
 
 * ``retz.database.url = jdbc:h2:mem:retz-server;DB_CLOSE_DELAY=-1`` : JDBC access URL
 * ``retz.database.driver = org.h2.Driver`` : JDBC Driver name

--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -49,7 +49,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class Client implements AutoCloseable {
 
     public static final String VERSION_STRING;
-    public static final int MAX_BIN_SIZE = (int) DownloadFileRequest.MAX_FILE_SIZE;
 
     static final Logger LOG = LoggerFactory.getLogger(Client.class);
 
@@ -193,8 +192,6 @@ public class Client implements AutoCloseable {
         } else if (size == 0) {
             // not bytes to save;
             return 0;
-        } else if (size > MAX_BIN_SIZE) {
-            throw new IOException("Download file too large: " + size);
         }
         try {
             return IOUtils.copy(conn.getInputStream(), out);

--- a/retz-common/src/main/java/io/github/retz/misc/Pair.java
+++ b/retz-common/src/main/java/io/github/retz/misc/Pair.java
@@ -16,8 +16,6 @@
  */
 package io.github.retz.misc;
 
-import java.util.Objects;
-
 public class Pair<T1, T2> {
     private final T1 t1;
     private final T2 t2;

--- a/retz-common/src/main/java/io/github/retz/misc/Receivable.java
+++ b/retz-common/src/main/java/io/github/retz/misc/Receivable.java
@@ -1,0 +1,5 @@
+package io.github.retz.misc;
+
+public interface Receivable<T, E extends Throwable> {
+    void receive(T value) throws E;
+}

--- a/retz-common/src/main/java/io/github/retz/misc/Receivable.java
+++ b/retz-common/src/main/java/io/github/retz/misc/Receivable.java
@@ -1,3 +1,19 @@
+/**
+ *    Retz
+ *    Copyright (C) 2016-2017 Nautilus Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package io.github.retz.misc;
 
 public interface Receivable<T, E extends Throwable> {

--- a/retz-common/src/main/java/io/github/retz/misc/Triad.java
+++ b/retz-common/src/main/java/io/github/retz/misc/Triad.java
@@ -1,3 +1,19 @@
+/**
+ *    Retz
+ *    Copyright (C) 2016-2017 Nautilus Technologies, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package io.github.retz.misc;
 
 public class Triad<T1, T2, T3> {

--- a/retz-common/src/main/java/io/github/retz/misc/Triad.java
+++ b/retz-common/src/main/java/io/github/retz/misc/Triad.java
@@ -1,0 +1,25 @@
+package io.github.retz.misc;
+
+public class Triad<T1, T2, T3> {
+    private final T1 t1;
+    private final T2 t2;
+    private final T3 t3;
+
+    public Triad(T1 t1, T2 t2, T3 t3) {
+        this.t1 = t1;
+        this.t2 = t2;
+        this.t3 = t3;
+    }
+
+    public T1 left() {
+        return t1;
+    }
+
+    public T2 center() {
+        return t2;
+    }
+
+    public T3 right() {
+        return t3;
+    }
+}

--- a/retz-common/src/main/java/io/github/retz/protocol/DownloadFileRequest.java
+++ b/retz-common/src/main/java/io/github/retz/protocol/DownloadFileRequest.java
@@ -26,8 +26,6 @@ import java.util.Objects;
 
 // Request to get text file; maps to files/read API of Mesos
 public class DownloadFileRequest extends Request {
-    public static long MAX_FILE_SIZE = 65536 * 1024; // in bytes
-
     private int id;
     private String file;
     //private long offset;

--- a/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
@@ -56,6 +56,7 @@ public class RetzScheduler implements Scheduler {
     }
 
     private final ResourceQuantity MAX_JOB_SIZE;
+    private final Long MAX_FILE_SIZE;
     private final ObjectMapper MAPPER = new ObjectMapper();
     private final Map<String, Protos.Offer> OFFER_STOCK = new ConcurrentHashMap<>();
     private final Planner PLANNER;
@@ -72,6 +73,7 @@ public class RetzScheduler implements Scheduler {
         this.slaves = new ConcurrentHashMap<>();
         this.filters = Protos.Filters.newBuilder().setRefuseSeconds(conf.getServerConfig().getRefuseSeconds()).build();
         MAX_JOB_SIZE = conf.getServerConfig().getMaxJobSize();
+        MAX_FILE_SIZE = conf.getServerConfig().getMaxFileSize();
     }
 
     @Override
@@ -439,4 +441,6 @@ public class RetzScheduler implements Scheduler {
     public ResourceQuantity maxJobSize() {
         return MAX_JOB_SIZE;
     }
+
+    public Long maxFileSize() { return MAX_FILE_SIZE; }
 }

--- a/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
@@ -47,6 +47,8 @@ public class ServerConfiguration extends FileConfiguration {
     public static final String DEFAULT_MAX_DISK = "1024"; // in MB
     public static final String MAX_LIST_JOB_SIZE = "retz.max.list-jobs";
     public static final String DEFAULT_MAX_LIST_JOB_SIZE = "65536";
+    public static final String MAX_FILE_SIZE = "retz.max.file-size";
+    public static final String DEFAULT_MAX_FILE_SIZE = Long.toString(65536 * 1024); // in bytes
 
     // Mesos connections and so on
     static final String MESOS_LOC_KEY = "retz.mesos";
@@ -142,7 +144,7 @@ public class ServerConfiguration extends FileConfiguration {
             throw new IllegalArgumentException(MESOS_REFUSE_SECONDS + " must be positive integer");
         }
 
-        LOG.info("Mesos master={}, principal={}, role={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}",
+        LOG.info("Mesos master={}, principal={}, role={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}",
                 getMesosMaster(), getPrincipal(), getRole(), MAX_SIMULTANEOUS_JOBS, maxSimultaneousJobs,
                 DATABASE_URL, databaseURL,
                 MAX_STOCK_SIZE, getMaxStockSize(),
@@ -150,7 +152,8 @@ public class ServerConfiguration extends FileConfiguration {
                 MESOS_REFUSE_SECONDS, getRefuseSeconds(),
                 GC_LEEWAY, getGcLeeway(),
                 GC_INTERVAL, getGcInterval(),
-                MAX_LIST_JOB_SIZE, getMaxJobSize());
+                MAX_LIST_JOB_SIZE, getMaxJobSize(),
+                MAX_FILE_SIZE, getMaxFileSize());
     }
 
     public ServerConfiguration(String file) throws IOException, URISyntaxException {
@@ -255,6 +258,10 @@ public class ServerConfiguration extends FileConfiguration {
 
     public int getMaxListJobSize() {
         return Integer.parseInt(properties.getProperty(MAX_LIST_JOB_SIZE, DEFAULT_MAX_LIST_JOB_SIZE));
+    }
+
+    public long getMaxFileSize() {
+        return Long.parseLong(properties.getProperty(MAX_FILE_SIZE, DEFAULT_MAX_FILE_SIZE));
     }
 
     public Properties copyAsProperties() {

--- a/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
+++ b/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
@@ -179,8 +179,12 @@ public class JobRequestHandler {
                 if (statusCode == 200) {
                     Long length = triad.right().left();
                     InputStream io = triad.right().right();
+                    Long maxFileSize = scheduler.get().maxFileSize();
+                    if (0 < maxFileSize && maxFileSize < length) {
+                        throw new IOException("Stream file too large: " + length + " < " + maxFileSize);
+                    }
                     res.raw().setHeader("Content-Length", length.toString());
-                    LOG.debug("start streaming of {} bytes", length);
+                    LOG.info("start streaming of {} bytes", length);
                     IOUtils.copyLarge(io, res.raw().getOutputStream());
                 } else {
                     res.body(triad.center());

--- a/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
+++ b/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
@@ -180,8 +180,10 @@ public class JobRequestHandler {
                     Long length = triad.right().left();
                     InputStream io = triad.right().right();
                     Long maxFileSize = scheduler.get().maxFileSize();
-                    if (0 < maxFileSize && maxFileSize < length) {
-                        throw new IOException("Stream file too large: " + length + " < " + maxFileSize);
+                    if (length < 0) {
+                        throw new IOException("content length is negative: " + length);
+                    } else if (0 <= maxFileSize && maxFileSize < length) { // negative maxFileSize indicates no limit
+                        throw new IOException("stream file too large: " + length + " < " + maxFileSize);
                     }
                     res.raw().setHeader("Content-Length", length.toString());
                     LOG.debug("start streaming of {} bytes for {}", length, file);

--- a/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
+++ b/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
@@ -184,8 +184,9 @@ public class JobRequestHandler {
                         throw new IOException("Stream file too large: " + length + " < " + maxFileSize);
                     }
                     res.raw().setHeader("Content-Length", length.toString());
-                    LOG.info("start streaming of {} bytes", length);
+                    LOG.debug("start streaming of {} bytes for {}", length, file);
                     IOUtils.copyLarge(io, res.raw().getOutputStream());
+                    LOG.debug("end streaming for {}", file);
                 } else {
                     res.body(triad.center());
                 }

--- a/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
+++ b/retz-server/src/main/java/io/github/retz/web/JobRequestHandler.java
@@ -187,7 +187,7 @@ public class JobRequestHandler {
                     }
                     res.raw().setHeader("Content-Length", length.toString());
                     LOG.debug("start streaming of {} bytes for {}", length, file);
-                    IOUtils.copyLarge(io, res.raw().getOutputStream());
+                    IOUtils.copyLarge(io, res.raw().getOutputStream(), 0, length);
                     LOG.debug("end streaming for {}", file);
                 } else {
                     res.body(triad.center());

--- a/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
+++ b/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
@@ -42,6 +42,7 @@ public class ServerConfigurationTest {
         assertNotEquals("root", config.getUserName());
 
         assertEquals(42, config.getMaxListJobSize());
+        assertEquals(12345, config.getMaxFileSize());
     }
 
     @Test(expected=IllegalArgumentException.class)

--- a/retz-server/src/test/resources/retz.properties
+++ b/retz-server/src/test/resources/retz.properties
@@ -27,6 +27,7 @@ retz.schedule.results = file://path/to/dir/
 retz.schedule.retry = 5
 
 retz.max.list-jobs = 42
+retz.max.file-size = 12345
 
 retz.tls.keystore.file = path/to/keystore.jsk
 retz.tls.keystore.pass = foobar


### PR DESCRIPTION
This is a fix discussed in https://github.com/retz/retz/issues/124 .

I made the existing max size still remains by server configuration's default value. Set `retz.max.file-size = 0` indicates there's no limit for the file size downloaded from Mesos.

I removed the file size check in the client because I think the file size to download is a concern of the application which uses Retz Client but not Retz Client itself.

Could you consider merging this fix?