### PR TITLE
Fix potential resource leakage in build.gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,10 +150,12 @@ def makePropertyFile(basedir, testType, name, version) {
 
     // Bundle correctly corresponding file name; See RetzScheduler.setJarUri
     def prop = new Properties()
-    def propFile = new File("${basedir}/resources/${testType}/retz-server.properties")
     prop.setProperty("servername", serverName)
+    def propFile = new File(subdir, "retz-server.properties")
     propFile.createNewFile()
-    prop.store(propFile.newWriter(), null)
+    propFile.withOutputStream { out ->
+        prop.store(out, null)
+    }
 }
 
 def makeClientPropertyFile(basedir, testType, name, version) {
@@ -165,10 +167,12 @@ def makeClientPropertyFile(basedir, testType, name, version) {
     def fullVersion = "${name}-${version} (${gitVersion()})"
 
     def prop = new Properties()
-    def propFile = new File("${basedir}/resources/${testType}/retz-client.properties")
     prop.setProperty("version", fullVersion)
+    def propFile = new File(subdir, "retz-client.properties")
     propFile.createNewFile()
-    prop.store(propFile.newWriter(), null)
+    propFile.withOutputStream { out ->
+        prop.store(out, null)
+    }
 }
 
 


### PR DESCRIPTION
Using `File.withOutputStream { ... }` instead of `newWriter()` closes the created file after writing contents, and may fix potential character encoding problems (these files will be read as ASCII text via `ResourceBundle` class).