### PR TITLE
Use `Wrapper.distributionType` instead of URL manipulation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -402,7 +402,7 @@ project('retz-inttest') {
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.0'
-    distributionUrl = distributionUrl.replace("bin", "all")
+    distributionType = 'ALL'
 }
 
 buildScan {


### PR DESCRIPTION
`Wrapper.distributionType` has been introduced since Gradle 3.1, and may be more resilient than manipulating distribution URL.