### PR TITLE
Fix content length data type to download files

### DIFF
--- a/retz-client/src/main/java/io/github/retz/web/Client.java
+++ b/retz-client/src/main/java/io/github/retz/web/Client.java
@@ -141,7 +141,7 @@ public class Client implements AutoCloseable {
     }
 
     // @return int content size written to OutputStream
-    public int getBinaryFile(int id, String file, OutputStream out) throws IOException {
+    public long getBinaryFile(int id, String file, OutputStream out) throws IOException {
         String date = TimestampHelper.now();
         // Encode path forcibly since we return decoded path by list files
         String encodedFile = file;
@@ -200,15 +200,15 @@ public class Client implements AutoCloseable {
             }
         }
 
-        int size = conn.getContentLength();
+        long size = conn.getContentLengthLong();
         if (size < 0) {
             throw new IOException("Illegal content length:" + size);
         } else if (size == 0) {
-            // not bytes to save;
+            // no bytes to save;
             return 0;
         }
         try {
-            return IOUtils.copy(conn.getInputStream(), out);
+            return IOUtils.copyLarge(conn.getInputStream(), out, 0, size);
         } finally {
             conn.disconnect();
         }

--- a/retz-inttest/src/test/java/io/github/retz/inttest/RegressionTest.java
+++ b/retz-inttest/src/test/java/io/github/retz/inttest/RegressionTest.java
@@ -76,7 +76,7 @@ public class RegressionTest extends IntTestBase {
             assertThat(runRes.state(), is(Job.JobState.FINISHED));
 
             ByteArrayOutputStream out = new ByteArrayOutputStream();
-            int res = client.getBinaryFile(runRes.id(), filename, out);
+            long res = client.getBinaryFile(runRes.id(), filename, out);
             assertEquals(9, res);
             assertEquals("palmface\n", out.toString(StandardCharsets.UTF_8.toString()));
         }


### PR DESCRIPTION
In the recent version, Retz server can provide streams of large file. However, I got a weird error of `java.io.IOException: Illegal content length:-1` when I tried to download a file of 10GiB and found the client uses `getContentLength` method.

According to [Java docs](https://docs.oracle.com/javase/7/docs/api/java/net/URLConnection.html#getContentLength()), the method returns `-1` if a length exceeds the limit of int.

I think we need to handle length of large file on the client side as we support it on the server side. So could you consider merging this fix?
