### PR TITLE
Configurable recovery on reconnect

### DIFF
--- a/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
@@ -136,8 +136,10 @@ public class RetzScheduler implements Scheduler {
         if (oldFrameworkId.isPresent()) {
             if (oldFrameworkId.get().equals(frameworkId.getValue())) {
                 // framework exists. nothing to do
-                LOG.info("Framework id={} existed in past. Recovering any running jobs...", frameworkId.getValue());
-                maybeRecoverRunning(driver);
+                if (conf.fileConfig.getRecoverOnReconnect()) {
+                    LOG.info("Framework id={} existed in past. Recovering any running jobs...", frameworkId.getValue());
+                    maybeRecoverRunning(driver);
+                }
             } else {
                 LOG.error("Old different framework ({}) exists (!= {}). Quitting",
                         oldFrameworkId.get(), frameworkId.getValue());
@@ -186,8 +188,10 @@ public class RetzScheduler implements Scheduler {
                 .toString();
         this.master = Optional.of(newMaster);
         StatusCache.updateMaster(newMaster);
-        LOG.info("Reconnected to master {}", newMaster);
-        maybeRecoverRunning(driver);
+        if (conf.fileConfig.getRecoverOnReconnect()) {
+            LOG.info("Reconnected to master {}", newMaster);
+            maybeRecoverRunning(driver);
+        }
     }
 
     @Override

--- a/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
@@ -62,6 +62,8 @@ public class ServerConfiguration extends FileConfiguration {
     static final int DEFAULT_MESOS_REFUSE_SECONDS = 3;
     static final String MESOS_FAILOVER_TIMEOUT = "retz.mesos.failover.timeout";
     static final int DEFAULT_MESOS_FAILOVER_TIMEOUT = 3600 * 24 * 7;
+    static final String RECOVER_ON_RECONNECT = "retz.recover-on-reconnect";
+    static final String DEFAULT_RECOVER_ON_RECONNECT = "true";
 
     // Not yet used
     static final String QUEUE_MAX = "retz.max.queue";
@@ -270,6 +272,12 @@ public class ServerConfiguration extends FileConfiguration {
             return Integer.parseInt(properties.getProperty(MESOS_FAILOVER_TIMEOUT));
         }
         return DEFAULT_MESOS_FAILOVER_TIMEOUT;
+    }
+
+    public boolean getRecoverOnReconnect() {
+        return Boolean.parseBoolean(properties.getProperty(
+                RECOVER_ON_RECONNECT,
+                DEFAULT_RECOVER_ON_RECONNECT));
     }
 
     public Properties copyAsProperties() {

--- a/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
+++ b/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
@@ -43,6 +43,7 @@ public class ServerConfigurationTest {
 
         assertEquals(42, config.getMaxListJobSize());
         assertEquals(12345, config.getMaxFileSize());
+        assertEquals(false, config.getRecoverOnReconnect());
     }
 
     @Test(expected=IllegalArgumentException.class)

--- a/retz-server/src/test/resources/retz.properties
+++ b/retz-server/src/test/resources/retz.properties
@@ -25,6 +25,7 @@ retz.access.key = deadbeef
 retz.access.secret = cafebabe
 retz.schedule.results = file://path/to/dir/
 retz.schedule.retry = 5
+retz.recover-on-reconnect = false
 
 retz.max.list-jobs = 42
 retz.max.file-size = 12345


### PR DESCRIPTION
Now RetzScheduler restarts all `STARTING` and `STARTED` jobs after re-connecting mesos-master or restarting Retz server. In our use-cases, we don't want to stop any running jobs automatically because most jobs are long-live.
So we would like to introduce a configure option to toggle this recovery behavior.
Since I could miss some corner cases, any comment/advise is welcome. :)

Addresses #158, #180