### PR TITLE
Modify CircleCI config for using workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
 version: 2
+
+defaults: &defaults
+  working_directory: ~/workspace
+  docker:
+    - image: circleci/openjdk:8
+
 jobs:
   build:
-    working_directory: ~/workspace
-    docker:
-      - image: circleci/openjdk:8
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
@@ -15,3 +19,33 @@ jobs:
              - "~/.gradle"
       - store_test_results:
           path: "build/all-test-report/test/"
+      - persist_to_workspace:
+          root: ~/workspace
+          paths:
+            - .
+
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/workspace
+      - restore_cache:
+          key: retz-{{ checksum "build.gradle" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+      - run: ./gradlew -i publish
+
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/


### PR DESCRIPTION
This PR modifies CircleCI build configuration for using workflow.

This workflow includes the following jobs:
- `build`: Corresponding to the Gradle build task ( the same as has been used so far ).
- `deploy`:  Uploading project artifacts to Maven repository.
  - This job will be run when `build` job finishes successfully and only for master branch and any tags.
