### PR TITLE
Fix Scalacheck doesn't outputs properly report

### DIFF
--- a/retz-common/src/test/scala/AuthenticatorPropTest.scala
+++ b/retz-common/src/test/scala/AuthenticatorPropTest.scala
@@ -21,14 +21,14 @@ import org.scalacheck.{Gen, Prop}
 import org.scalatest.junit.JUnitSuite
 import org.scalatest.prop.Checkers
 
-class AuthenticatorProp extends JUnitSuite {
+class AuthenticatorPropTest extends JUnitSuite {
 
   val nonEmptyString = Gen.oneOf(Gen.alphaLowerStr, Gen.alphaNumStr, Gen.alphaUpperStr) suchThat (_.nonEmpty)
   val verb = Gen.oneOf("PUT", "GET", "DELETE", "POST", "PATCH")
 
   @Test
   def encodeDecode(): Unit = {
-    Checkers.check(Prop.forAll(nonEmptyString, nonEmptyString, nonEmptyString, verb, nonEmptyString) {
+    Checkers.check(Prop.forAllNoShrink(nonEmptyString, nonEmptyString, nonEmptyString, verb, nonEmptyString) {
       (key: String, secret: String, path: String, verb: String, md5: String) => {
         val authenticator = new HmacSHA256Authenticator(key, secret)
         val timestamp = TimestampHelper.now()
@@ -45,7 +45,7 @@ class AuthenticatorProp extends JUnitSuite {
 
   @Test
   def noop(): Unit = {
-    Checkers.check(Prop.forAll(nonEmptyString, nonEmptyString, nonEmptyString, verb, nonEmptyString) {
+    Checkers.check(Prop.forAllNoShrink(nonEmptyString, nonEmptyString, nonEmptyString, verb, nonEmptyString) {
       (key: String, signature: String, path: String, verb: String, md5: String) => {
         val authenticator = new NoopAuthenticator(key)
         val date = TimestampHelper.now()

--- a/retz-server/src/test/scala/io/github/retz/scheduler/PlannerPropTest.scala
+++ b/retz-server/src/test/scala/io/github/retz/scheduler/PlannerPropTest.scala
@@ -69,7 +69,7 @@ class PlannerPropTest extends JUnitSuite {
   var fid : String = "framewark-id"
   @Test
   def plannerInvariantProp(): Unit = {
-    Checkers.check(Prop.forAll(
+    Checkers.check(Prop.forAllNoShrink(
       Gen.oneOf("naive", "priority", "fifo", "priority2"),
       RetzDataGen.application(owner),
       jobs,

--- a/retz-server/src/test/scala/io/github/retz/scheduler/ResourcePropTest.scala
+++ b/retz-server/src/test/scala/io/github/retz/scheduler/ResourcePropTest.scala
@@ -28,7 +28,7 @@ import org.scalatest.junit.JUnitSuite
 import org.scalatest.prop.Checkers
 
 // A property to correctly decode mesos.Proto.Resource to retz.mesos.Resource
-class ResourceProp extends JUnitSuite {
+class ResourcePropTest extends JUnitSuite {
   // val nat = Gen.oneOf(Gen.posInt, 0) // This does not somehow work
   val nat = for {i <- Gen.chooseNum(0, 65536)} yield i.toInt
   // val pos = Gen.posInt // This does not work somehow too
@@ -36,7 +36,7 @@ class ResourceProp extends JUnitSuite {
 
   @Test
   def decodeResource(): Unit = {
-    Checkers.check(Prop.forAll(pos, pos, nat, nat) {
+    Checkers.check(Prop.forAllNoShrink(pos, pos, nat, nat) {
       (cpus: Int, mem: Int, disk: Int, gpu: Int) => {
         println(cpus, mem, disk, gpu)
 
@@ -61,7 +61,7 @@ class ResourceProp extends JUnitSuite {
 
   @Test
   def resourceQuantityProp(): Unit = {
-    Checkers.check(Prop.forAll(Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int], resourceQuantity) {
+    Checkers.check(Prop.forAllNoShrink(Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int], Gen.posNum[Int], resourceQuantity) {
       (cpus: Int, mem: Int, disk: Int, gpus: Int, ports: Int, q: ResourceQuantity) => {
         val job = new Job("x", "a", new Properties(), cpus+1, mem + 32, disk + 32, gpus, ports)
         val fit = q.fits(job)
@@ -81,7 +81,7 @@ class ResourceProp extends JUnitSuite {
       yield new Resource(cpus.toDouble, mem, disk, gpus, util.Arrays.asList())
   @Test
   def resourceCutProp() : Unit = {
-    Checkers.check(Prop.forAll(Gen.nonEmptyListOf(resource)) {
+    Checkers.check(Prop.forAllNoShrink(Gen.nonEmptyListOf(resource)) {
       (resources: List[Resource]) => {
         val total = resources.foldLeft(new Resource(0, 0, 0))( (t, r) => {
           t.merge(r)


### PR DESCRIPTION
Sometimes Scalacheck won't outputs properly report the failing case with shrinker.
