### PR TITLE
Add a metrics of stanchion job queue length

### DIFF
--- a/retz-common/src/main/java/io/github/retz/bean/StatusMXBean.java
+++ b/retz-common/src/main/java/io/github/retz/bean/StatusMXBean.java
@@ -24,5 +24,6 @@ public interface StatusMXBean {
     int getRunningLength();
     String getServerVersion();
     String getStatus();
+    int getStanchionQueueLength();
     String getVersion();
 }

--- a/retz-common/src/main/java/io/github/retz/protocol/StatusResponse.java
+++ b/retz-common/src/main/java/io/github/retz/protocol/StatusResponse.java
@@ -32,6 +32,7 @@ public class StatusResponse extends Response {
     private int offers;
     private ResourceQuantity totalOffered;
     private Optional<String> master;
+    private int stanchionQueueLength;
     private final String serverVersion;
 
     @JsonCreator
@@ -42,6 +43,7 @@ public class StatusResponse extends Response {
                           @JsonProperty("offers") int offers,
                           @JsonProperty("totalOffered") ResourceQuantity totalOffered,
                           @JsonProperty("master") Optional<String> master,
+                          @JsonProperty("stanchionQueueLength") int stanchionQueueLength,
                           @JsonProperty("serverVersion") String serverVersion) {
         this.queueLength = queueLength;
         this.runningLength = runningLength;
@@ -50,6 +52,7 @@ public class StatusResponse extends Response {
         this.offers = offers;
         this.totalOffered = totalOffered;
         this.master = (master == null) ? Optional.empty() : master;
+        this.stanchionQueueLength = stanchionQueueLength;
         this.serverVersion = serverVersion;
     }
 
@@ -96,6 +99,11 @@ public class StatusResponse extends Response {
         return master;
     }
 
+    @JsonGetter("stanchionQueueLength")
+    public int stanchionQueueLength() {
+        return stanchionQueueLength;
+    }
+
     @JsonGetter("serverVersion")
     public String serverVersion() {
         return serverVersion;
@@ -110,6 +118,10 @@ public class StatusResponse extends Response {
         this.queueLength = queueLength;
         this.runningLength = runningLength;
         this.totalUsed = totalUsed;
+    }
+
+    public void setStanchionQueueLength(int stanchionQueueLength) {
+        this.stanchionQueueLength = stanchionQueueLength;
     }
 
     public void setMaster(String master) {

--- a/retz-server/src/main/java/io/github/retz/jmx/StatusAdapter.java
+++ b/retz-server/src/main/java/io/github/retz/jmx/StatusAdapter.java
@@ -61,6 +61,11 @@ public class StatusAdapter implements StatusMXBean {
         return getStatusResponse().version();
     }
 
+    @Override
+    public int getStanchionQueueLength() {
+        return getStatusResponse().stanchionQueueLength();
+    }
+
     private StatusResponse getStatusResponse() {
         return StatusCache.getRawStatusResponse();
     }

--- a/retz-server/src/main/java/io/github/retz/scheduler/Stanchion.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/Stanchion.java
@@ -28,7 +28,7 @@ import io.github.retz.misc.LogUtil;
 public final class Stanchion {
     private static final Logger LOG = LoggerFactory.getLogger(RetzScheduler.class);
 
-    static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+    static final ThreadPoolExecutor EXECUTOR = (ThreadPoolExecutor) Executors.newFixedThreadPool(1);
 
     private Stanchion() {
     }
@@ -55,5 +55,9 @@ public final class Stanchion {
         } catch (InterruptedException | ExecutionException e) {
             throw new IOException(e);
         }
+    }
+
+    public static int getQueueLength() {
+       return EXECUTOR.getQueue().size();
     }
 }

--- a/retz-server/src/main/java/io/github/retz/web/StatusCache.java
+++ b/retz-server/src/main/java/io/github/retz/web/StatusCache.java
@@ -24,6 +24,7 @@ import io.github.retz.protocol.StatusResponse;
 import io.github.retz.protocol.data.Job;
 import io.github.retz.protocol.data.ResourceQuantity;
 import io.github.retz.scheduler.RetzScheduler;
+import io.github.retz.scheduler.Stanchion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,6 +56,7 @@ public class StatusCache implements Runnable {
     @Override
     public void run() {
         StatusCache.updateUsedResources();
+        StatusCache.updateStanchionStatus();
         if (on) {
             SCHEDULER.schedule(new StatusCache(interval), interval, TimeUnit.SECONDS);
         }
@@ -105,6 +107,12 @@ public class StatusCache implements Runnable {
 
         LOG.debug("poke len(Q)={}, len(Running)={}, totalUsed={}",
                 queueLength, running, total);
+    }
+
+    public static void updateStanchionStatus() {
+        synchronized (STATUS_RESPONSE_CACHE) {
+            STATUS_RESPONSE_CACHE.setStanchionQueueLength(Stanchion.getQueueLength());
+        }
     }
 
     public static void setUsedResources(int queueLength, int runningLenght, ResourceQuantity totalUsed) {


### PR DESCRIPTION
## Summary

Add new metrics `stanchionQueueLength` for figuring out whether stanchion works well.

## Background

Retz has an additional job queue in Stanchion for processing serialized internal jobs such as killing a job, handling resource offers, handling slave lost, and so on... This `stanchionQueueLength` helps us to understand how it consumes jobs correctly.