### PR TITLE
Send all jobs to planner

### DIFF
--- a/retz-server/src/main/dist/etc/retz.properties
+++ b/retz-server/src/main/dist/etc/retz.properties
@@ -56,6 +56,9 @@ retz.access.secret = cafebabe
 ## Choose Planner from one of {naive, priority}
 retz.planner.name = naive
 
+## Strategy to pick jobs from the job queue
+## retz.job-queue-strategy = fit
+
 ## JMX Port, shared by retz-server and retz-admin
 ## retz.jmx.port = 9999
 

--- a/retz-server/src/main/java/io/github/retz/db/Database.java
+++ b/retz-server/src/main/java/io/github/retz/db/Database.java
@@ -544,36 +544,44 @@ public class Database {
     }
 
     // orderBy must not have any duplication
-    public List<Job> findFit(List<String> orderBy, int cpu, int memMB) throws IOException {
+    public List<Job> findAll(List<String> orderBy) throws IOException {
         List<Job> ret = new ArrayList<>();
         String orders = orderBy.stream().map(s -> s + " ASC").collect(Collectors.joining(", "));
         try (Connection conn = dataSource.getConnection(); //pool.getConnection();
              PreparedStatement p = conn.prepareStatement("SELECT * FROM jobs WHERE state='QUEUED' ORDER BY " + orders)) {
-            conn.setAutoCommit(true);
-
             try (ResultSet res = p.executeQuery()) {
-                int totalCpu = 0;
-                int totalMem = 0;
-
-                while (res.next() && totalCpu <= cpu && totalMem <= memMB) {
+                while (res.next()) {
                     String json = res.getString("json");
                     Job job = mapper.readValue(json, Job.class);
-
                     if (job == null) {
                         throw new AssertionError("Cannot be null!!");
-                    } else if (totalCpu + job.resources().getCpu() <= cpu && totalMem + job.resources().getMemMB() <= memMB) {
-                        ret.add(job);
-                        totalCpu += job.resources().getCpu();
-                        totalMem += job.resources().getMemMB();
-                    } else {
-                        break;
                     }
+                    ret.add(job);
                 }
             }
             return ret;
         } catch (SQLException | IOException e) {
-            throw new IOException(MessageFormat.format("Database.findFit({0}, {1}) failed", cpu, memMB), e);
+            throw new IOException("Database.findAll() failed", e);
         }
+    }
+
+    public List<Job> findFit(List<String> orderBy, int cpu, int memMB) throws IOException {
+        List<Job> ret = new ArrayList<>();
+        int totalCpu = 0;
+        int totalMem = 0;
+
+        for (Job job: findAll(orderBy)) {
+            if (totalCpu <= cpu && totalMem <= memMB) {
+                if (totalCpu + job.resources().getCpu() <= cpu && totalMem + job.resources().getMemMB() <= memMB) {
+                    ret.add(job);
+                    totalCpu += job.resources().getCpu();
+                    totalMem += job.resources().getMemMB();
+                } else {
+                    break;
+                }
+            }
+        }
+        return ret;
     }
 
     public List<Job> queued(int limit) throws IOException {

--- a/retz-server/src/main/java/io/github/retz/scheduler/JobQueue.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/JobQueue.java
@@ -99,6 +99,10 @@ public final class JobQueue {
         return maybeJob;
     }
 
+    public static List<Job> findAll(List<String> orderBy) throws IOException {
+        return Database.getInstance().findAll(orderBy);
+    }
+
     // @doc take as much jobs as in the max cpu/memMB
     public static List<Job> findFit(List<String> orderBy, ResourceQuantity total) throws IOException {
         return Database.getInstance().findFit(orderBy, total.getCpu(), total.getMemMB());

--- a/retz-server/src/main/java/io/github/retz/scheduler/JobQueue.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/JobQueue.java
@@ -99,8 +99,8 @@ public final class JobQueue {
         return maybeJob;
     }
 
-    public static List<Job> findAll(List<String> orderBy) throws IOException {
-        return Database.getInstance().findAll(orderBy);
+    public static List<Job> findAll(List<String> orderBy, int limit) throws IOException {
+        return Database.getInstance().findAll(orderBy, limit);
     }
 
     // @doc take as much jobs as in the max cpu/memMB

--- a/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/RetzScheduler.java
@@ -226,9 +226,9 @@ public class RetzScheduler implements Scheduler {
                 offerStock.clear();
             }
 
-            List<Job> jobs = new ArrayList<>();
-            switch (conf.getServerConfig().getJobQueueStrategy()) {
-                case Fit:
+            final List<Job> jobs;
+            switch (conf.getServerConfig().getJobQueueType()) {
+                case FIT:
                     ResourceQuantity total = new ResourceQuantity();
                     for (Protos.Offer offer : available) {
                         LOG.debug("offer: {}", offer);
@@ -240,13 +240,12 @@ public class RetzScheduler implements Scheduler {
                     jobs = JobQueue.findFit(planner.orderBy(), total);
                     LOG.debug("found {} jobs fit for {}", jobs.size(), total.toString());
                     break;
-                case All:
-                    jobs = JobQueue.findAll(planner.orderBy());
-                    LOG.debug("found {} jobs", jobs.size());
+                case ALL:
+                    jobs = JobQueue.findAll(planner.orderBy(), conf.getServerConfig().getJobQueueAllLimit());
+                    LOG.debug("found {} / {} jobs", jobs.size(), conf.getServerConfig().getJobQueueAllLimit());
                     break;
                 default:
-                    LOG.debug("skip unknown strategy");
-                    break;
+                    throw new AssertionError("unknown job queue type");
             }
             handleAll(available, jobs, driver);
             // As this section is whole serialized by Stanchion, it is safe to do fetching jobs

--- a/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
@@ -87,20 +87,20 @@ public class ServerConfiguration extends FileConfiguration {
     private static final String DEFAULT_PLANNER_NAME = "fifo";
     private static final String[] PLANNER_NAMES = {"naive", "priority", "fifo", "priority2"};
 
-    private static final String JOB_QUEUE_STRATEGY = "retz.job-queue-strategy";
-    private static final String DEFAULT_JOB_QUEUE_STRATEGY = "all";
-    public enum JobQueueStrategy {
-        Fit("fit"),
-        All("all");
-        static JobQueueStrategy getStrategy(String s) {
-            switch(s.toLowerCase()) {
-                case "all": return JobQueueStrategy.All;
-                case "fit": return JobQueueStrategy.Fit;
+    private static final String JOB_QUEUE_TYPE = "retz.job-queue.type";
+    private static final String DEFAULT_JOB_QUEUE_TYPE = "all";
+    public enum JobQueueType {
+        FIT("fit"),
+        ALL("all");
+        static JobQueueType getType(String s) {
+            switch (s.toLowerCase()) {
+                case "all": return JobQueueType.ALL;
+                case "fit": return JobQueueType.FIT;
                 default: return null;
             }
         }
         private final String text;
-        JobQueueStrategy(final String text) {
+        JobQueueType(final String text) {
             this.text = text;
         }
         @Override
@@ -108,6 +108,8 @@ public class ServerConfiguration extends FileConfiguration {
             return text;
         }
     }
+    private static final String JOB_QUEUE_ALL_LIMIT = "retz.job-queue.all.limit";
+    private static final int DEFAULT_JOB_QUEUE_ALL_LIMIT = 10;
 
     private static final String ADDITIONAL_CLASSPATH = "retz.classpath";
     private static final String DEFAULT_ADDITIONAL_CLASSPATH = "/opt/retz-server/lib";
@@ -162,8 +164,8 @@ public class ServerConfiguration extends FileConfiguration {
             throw new IllegalArgumentException(MESOS_REFUSE_SECONDS + " must be positive integer");
         }
 
-        if (getJobQueueStrategy() == null) {
-            throw new IllegalArgumentException(JOB_QUEUE_STRATEGY + " must be either fir or all");
+        if (getJobQueueType() == null) {
+            throw new IllegalArgumentException(JOB_QUEUE_TYPE + " must be either fir or all");
         }
 
         LOG.info("Mesos master={}, principal={}, role={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}",
@@ -176,7 +178,7 @@ public class ServerConfiguration extends FileConfiguration {
                 GC_INTERVAL, getGcInterval(),
                 MAX_LIST_JOB_SIZE, getMaxJobSize(),
                 MAX_FILE_SIZE, getMaxFileSize(),
-                JOB_QUEUE_STRATEGY, getJobQueueStrategy());
+                JOB_QUEUE_TYPE, getJobQueueType());
         LOG.info("{}={}", MESOS_FAILOVER_TIMEOUT, getFailoverTimeout());
     }
 
@@ -268,7 +270,13 @@ public class ServerConfiguration extends FileConfiguration {
         return properties.getProperty(PLANNER_NAME, DEFAULT_PLANNER_NAME);
     }
 
-    public JobQueueStrategy getJobQueueStrategy() { return JobQueueStrategy.getStrategy(properties.getProperty(JOB_QUEUE_STRATEGY, DEFAULT_JOB_QUEUE_STRATEGY)); }
+    public JobQueueType getJobQueueType() {
+        return JobQueueType.getType(properties.getProperty(JOB_QUEUE_TYPE, DEFAULT_JOB_QUEUE_TYPE));
+    }
+
+    public int getJobQueueAllLimit() {
+        return getBoundedIntProperty(JOB_QUEUE_ALL_LIMIT, DEFAULT_JOB_QUEUE_ALL_LIMIT, -1, Integer.MAX_VALUE);
+    }
 
     public int getRefuseSeconds() {
         return getLowerboundedIntProperty(MESOS_REFUSE_SECONDS, DEFAULT_MESOS_REFUSE_SECONDS, 1);

--- a/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
@@ -87,6 +87,20 @@ public class ServerConfiguration extends FileConfiguration {
     private static final String DEFAULT_PLANNER_NAME = "fifo";
     private static final String[] PLANNER_NAMES = {"naive", "priority", "fifo", "priority2"};
 
+    private static final String JOB_QUEUE_STRATEGY = "retz.job-queue-strategy";
+    private static final String DEFAULT_JOB_QUEUE_STRATEGY = "all";
+    public enum JobQueueStrategy {
+        Fit,
+        All;
+        static JobQueueStrategy getStrategy(String s) {
+            switch(s) {
+                case "all": return JobQueueStrategy.All;
+                case "fit": return JobQueueStrategy.Fit;
+                default: return null;
+            }
+        }
+    }
+
     private static final String ADDITIONAL_CLASSPATH = "retz.classpath";
     private static final String DEFAULT_ADDITIONAL_CLASSPATH = "/opt/retz-server/lib";
 
@@ -138,6 +152,10 @@ public class ServerConfiguration extends FileConfiguration {
 
         if (getRefuseSeconds() < 1) {
             throw new IllegalArgumentException(MESOS_REFUSE_SECONDS + " must be positive integer");
+        }
+
+        if (getJobQueueStrategy() == null) {
+            throw new IllegalArgumentException(JOB_QUEUE_STRATEGY + " must be either fir or all");
         }
 
         LOG.info("Mesos master={}, principal={}, role={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}",
@@ -240,6 +258,8 @@ public class ServerConfiguration extends FileConfiguration {
     public String getPlannerName() {
         return properties.getProperty(PLANNER_NAME, DEFAULT_PLANNER_NAME);
     }
+
+    public JobQueueStrategy getJobQueueStrategy() { return JobQueueStrategy.getStrategy(properties.getProperty(JOB_QUEUE_STRATEGY, DEFAULT_JOB_QUEUE_STRATEGY)); }
 
     public int getRefuseSeconds() {
         return getLowerboundedIntProperty(MESOS_REFUSE_SECONDS, DEFAULT_MESOS_REFUSE_SECONDS, 1);

--- a/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
@@ -90,14 +90,22 @@ public class ServerConfiguration extends FileConfiguration {
     private static final String JOB_QUEUE_STRATEGY = "retz.job-queue-strategy";
     private static final String DEFAULT_JOB_QUEUE_STRATEGY = "all";
     public enum JobQueueStrategy {
-        Fit,
-        All;
+        Fit("fit"),
+        All("all");
         static JobQueueStrategy getStrategy(String s) {
-            switch(s) {
+            switch(s.toLowerCase()) {
                 case "all": return JobQueueStrategy.All;
                 case "fit": return JobQueueStrategy.Fit;
                 default: return null;
             }
+        }
+        private final String text;
+        JobQueueStrategy(final String text) {
+            this.text = text;
+        }
+        @Override
+        public String toString() {
+            return text;
         }
     }
 
@@ -158,7 +166,7 @@ public class ServerConfiguration extends FileConfiguration {
             throw new IllegalArgumentException(JOB_QUEUE_STRATEGY + " must be either fir or all");
         }
 
-        LOG.info("Mesos master={}, principal={}, role={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}",
+        LOG.info("Mesos master={}, principal={}, role={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}, {}={}",
                 getMesosMaster(), getPrincipal(), getRole(), MAX_SIMULTANEOUS_JOBS, maxSimultaneousJobs,
                 DATABASE_URL, databaseURL,
                 MAX_STOCK_SIZE, getMaxStockSize(),
@@ -167,7 +175,8 @@ public class ServerConfiguration extends FileConfiguration {
                 GC_LEEWAY, getGcLeeway(),
                 GC_INTERVAL, getGcInterval(),
                 MAX_LIST_JOB_SIZE, getMaxJobSize(),
-                MAX_FILE_SIZE, getMaxFileSize());
+                MAX_FILE_SIZE, getMaxFileSize(),
+                JOB_QUEUE_STRATEGY, getJobQueueStrategy());
         LOG.info("{}={}", MESOS_FAILOVER_TIMEOUT, getFailoverTimeout());
     }
 

--- a/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
+++ b/retz-server/src/main/java/io/github/retz/scheduler/ServerConfiguration.java
@@ -88,7 +88,7 @@ public class ServerConfiguration extends FileConfiguration {
     private static final String[] PLANNER_NAMES = {"naive", "priority", "fifo", "priority2"};
 
     private static final String JOB_QUEUE_TYPE = "retz.job-queue.type";
-    private static final String DEFAULT_JOB_QUEUE_TYPE = "all";
+    private static final String DEFAULT_JOB_QUEUE_TYPE = "fit";
     public enum JobQueueType {
         FIT("fit"),
         ALL("all");

--- a/retz-server/src/test/java/io/github/retz/scheduler/JobQueueTest.java
+++ b/retz-server/src/test/java/io/github/retz/scheduler/JobQueueTest.java
@@ -59,6 +59,7 @@ public class JobQueueTest {
                 Optional.empty(), "deadbeef", 0, new MesosContainer(), true);
         assertTrue(Applications.load(app));
 
+        String taskId = "foobar-taskid";
         int id = 0;
         Job job = new Job("appq", "b", null, 1000, 100000000, 0);
         job.schedule(id, TimestampHelper.now());
@@ -71,13 +72,12 @@ public class JobQueueTest {
             System.err.println(job2.size());
             assertFalse(job2.isEmpty());
             assertThat(job2.get(0).appid(), is(job.appid()));
-            JobQueue.starting(job2.get(0), Optional.empty(), "foobar-taskid");
+            JobQueue.starting(job2.get(0), Optional.empty(), taskId);
 
-            Optional<Job> j = Database.getInstance().getJobFromTaskId("foobar-taskid");
+            Optional<Job> j = Database.getInstance().getJobFromTaskId(taskId);
             assertTrue(j.isPresent());
         }
 
-        String taskId = "foobar-taskid";
         {
             JobQueue.started(taskId, "slaveId", Optional.empty());
             List<Job> fit = JobQueue.findFit(Arrays.asList("id"), new ResourceQuantity(1000, 100000000, 0, 0, 0, 0));
@@ -89,7 +89,6 @@ public class JobQueueTest {
         }
         assertEquals(1, JobQueue.size());
         assertEquals(1, JobQueue.countRunning());
-
 
         {
             JobQueue.finished(taskId, Optional.empty(), 0, TimestampHelper.now());
@@ -105,5 +104,54 @@ public class JobQueueTest {
         }
 
         Database.getInstance().safeDeleteApplication(app.getAppid());
+    }
+    @Test
+    public void findFit() throws Exception {
+        Application app = new Application("appq", Collections.emptyList(), Collections.emptyList(),
+                Optional.empty(), "deadbeef", 0, new MesosContainer(), true);
+        assertTrue(Applications.load(app));
+
+        String taskId = "foobar-taskid";
+        Job job1 = new Job("appq", "job1", null, 1000, 100000000, 0);
+        job1.schedule(0, TimestampHelper.now());
+        JobQueue.push(job1);
+        Job job2 = new Job("appq", "job2", null, 500, 2000000, 0);
+        job2.schedule(1, TimestampHelper.now());
+        JobQueue.push(job2);
+
+        {
+            List<Job> fit = JobQueue.findFit(Arrays.asList("id"), new ResourceQuantity(1001, 100000001, 0, 0, 0, 0));
+            for (Job j : fit) {
+                System.err.println(j.name() + " " + j.cmd());
+            }
+            System.err.println(fit.size());
+            assertEquals(fit.size(), 1);
+            assertThat(fit.get(0).appid(), is(job1.appid()));
+        }
+    }
+    @Test
+    public void findAll() throws Exception {
+        Application app = new Application("appq", Collections.emptyList(), Collections.emptyList(),
+                Optional.empty(), "deadbeef", 0, new MesosContainer(), true);
+        assertTrue(Applications.load(app));
+
+        String taskId = "foobar-taskid";
+        Job job1 = new Job("appq", "job1", null, 1000, 100000000, 0);
+        job1.schedule(0, TimestampHelper.now());
+        JobQueue.push(job1);
+        Job job2 = new Job("appq", "job2", null, 500, 2000000, 0);
+        job2.schedule(1, TimestampHelper.now());
+        JobQueue.push(job2);
+
+        {
+            List<Job> all = JobQueue.findAll(Arrays.asList("id"));
+            for (Job j : all) {
+                System.err.println(j.name() + " " + j.cmd());
+            }
+            System.err.println(all.size());
+            assertEquals(all.size(), 2);
+            assertThat(all.get(0).appid(), is(job1.appid()));
+            assertThat(all.get(1).appid(), is(job2.appid()));
+        }
     }
 }

--- a/retz-server/src/test/java/io/github/retz/scheduler/JobQueueTest.java
+++ b/retz-server/src/test/java/io/github/retz/scheduler/JobQueueTest.java
@@ -142,9 +142,12 @@ public class JobQueueTest {
         Job job2 = new Job("appq", "job2", null, 500, 2000000, 0);
         job2.schedule(1, TimestampHelper.now());
         JobQueue.push(job2);
+        Job job3 = new Job("appq", "job2", null, 500, 2000000, 0);
+        job3.schedule(2, TimestampHelper.now());
+        JobQueue.push(job3);
 
         {
-            List<Job> all = JobQueue.findAll(Arrays.asList("id"));
+            List<Job> all = JobQueue.findAll(Arrays.asList("id"), 2);
             for (Job j : all) {
                 System.err.println(j.name() + " " + j.cmd());
             }
@@ -152,6 +155,18 @@ public class JobQueueTest {
             assertEquals(all.size(), 2);
             assertThat(all.get(0).appid(), is(job1.appid()));
             assertThat(all.get(1).appid(), is(job2.appid()));
+        }
+
+        {
+            List<Job> all = JobQueue.findAll(Arrays.asList("id"), -1);
+            for (Job j : all) {
+                System.err.println(j.name() + " " + j.cmd());
+            }
+            System.err.println(all.size());
+            assertEquals(all.size(), 3);
+            assertThat(all.get(0).appid(), is(job1.appid()));
+            assertThat(all.get(1).appid(), is(job2.appid()));
+            assertThat(all.get(2).appid(), is(job3.appid()));
         }
     }
 }

--- a/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
+++ b/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
@@ -68,7 +68,7 @@ public class ServerConfigurationTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void wrongJobQueueStrategy() throws Exception {
-        String s = basicConfig + "retz.job-queue-strategy=hoge";
+        String s = basicConfig + "retz.job-queue.type=hoge";
         System.err.println(s);
         new ServerConfiguration(new ByteArrayInputStream(s.getBytes(UTF_8)));
     }

--- a/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
+++ b/retz-server/src/test/java/io/github/retz/scheduler/ServerConfigurationTest.java
@@ -25,6 +25,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
 public class ServerConfigurationTest {
+    String basicConfig = "retz.mesos = mesos.example.com:5050\n" +
+        "retz.mesos.principal = retz\n" +
+        "retz.bind  = http://localhost:9090\n" +
+        "retz.authentication = true\n" +
+        "retz.access.key = foobar\n" +
+        "retz.access.secret = bazbax\n";
+
     @Test
     public void tryLoadConfig() throws Exception {
         ServerConfiguration config = new ServerConfiguration("src/test/resources/retz.properties");
@@ -55,6 +62,13 @@ public class ServerConfigurationTest {
     @Test(expected = IllegalArgumentException.class)
     public void wrongConfig2() throws Exception {
         String s = "retz.mesos = mesos.example.com:5050\nretz.bind = http://example.com:90\nretz.access.key = foobar\nretz.access.secret = bazbax";
+        System.err.println(s);
+        new ServerConfiguration(new ByteArrayInputStream(s.getBytes(UTF_8)));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void wrongJobQueueStrategy() throws Exception {
+        String s = basicConfig + "retz.job-queue-strategy=hoge";
         System.err.println(s);
         new ServerConfiguration(new ByteArrayInputStream(s.getBytes(UTF_8)));
     }


### PR DESCRIPTION
Currently, we only pass limited number of jobs to planners, but some planners may want to evaluate all the jobs by themselves.

Some related topic has been discussed in https://github.com/retz/retz/issues/157 but we haven't concluded yet. My workaround here is let users configure it by the server configuration.

I didn't make the config `on/off` flag because we may want to add other strategy in the future.

Could you consider merging this change?